### PR TITLE
Add junit tests for status type and modify status implementation

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,7 +23,7 @@ public class Messages {
             + "not an interviewer phone number.";
     public static final String MESSAGE_INCORRECT_INTERVIEWER_AND_APPLICANT_PHONE_NUMBER =
             "The phone number you have keyed is is not an applicant nor an interviewer phone number.";
-    public static final String MESSAGE_INCORRENT_STATUS_APPLICANT = "Only applicants can be given this status";
+    public static final String MESSAGE_INCORRECT_STATUS_APPLICANT = "Only applicants can be given this status";
     public static final String MESSAGE_INCORRECT_STATUS_INTERVIEWER = "Only interviewers can be given this status";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INVALID_END_TIME = "The end time is before the start time!";

--- a/src/main/java/seedu/address/logic/commands/AddApplicantStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApplicantStatusCommand.java
@@ -56,6 +56,7 @@ public class AddApplicantStatusCommand extends Command {
         try {
             personToEdit = lastShownList
                     .stream()
+                    .parallel()
                     .filter(person -> person.getPhone().equals(phone))
                     .reduce((person, prev) -> person).get();
         } catch (NoSuchElementException e) {
@@ -63,7 +64,7 @@ public class AddApplicantStatusCommand extends Command {
         }
 
         if (!personToEdit.getPersonType().equals("APPLICANT")) {
-            throw new CommandException(Messages.MESSAGE_INCORRENT_STATUS_APPLICANT);
+            throw new CommandException(Messages.MESSAGE_INCORRECT_STATUS_APPLICANT);
         }
 
         Applicant editedPerson = new Applicant(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),

--- a/src/main/java/seedu/address/logic/commands/AddInterviewerStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInterviewerStatusCommand.java
@@ -55,6 +55,7 @@ public class AddInterviewerStatusCommand extends Command {
         try {
             personToEdit = lastShownList
                     .stream()
+                    .parallel()
                     .filter(person -> person.getPhone().equals(phone))
                     .reduce((person, prev) -> person).get();
         } catch (NoSuchElementException e) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -18,11 +18,18 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Applicant;
+import seedu.address.model.person.ApplicantStatus;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Interviewer;
+import seedu.address.model.person.InterviewerStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.enums.ApplicantState;
+import seedu.address.model.person.enums.InterviewerState;
+import seedu.address.model.person.enums.Type;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -96,6 +103,13 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Remark updatedRemark = personToEdit.getRemark(); // edit command does not allow editing remarks
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        if (personToEdit.getPersonType().equals(Type.APPLICANT.toString())) {
+            return new Applicant(updatedName, updatedPhone, updatedEmail, updatedRemark,
+                    new ApplicantStatus(ApplicantState.STAGEONE.toString()), updatedTags);
+        } else if (personToEdit.getPersonType().equals(Type.INTERVIEWER.toString())) {
+            return new Interviewer(updatedName, updatedPhone, updatedEmail, updatedRemark,
+                    new InterviewerStatus(InterviewerState.FREE.toString()), updatedTags);
+        }
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedRemark, updatedTags);
     }

--- a/src/main/java/seedu/address/logic/parser/AddApplicantStatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddApplicantStatusCommandParser.java
@@ -31,8 +31,9 @@ public class AddApplicantStatusCommandParser implements Parser<AddApplicantStatu
                     AddApplicantStatusCommand.MESSAGE_USAGE), ive);
         }
 
-        String status = argMultimap.getValue(PREFIX_STATUS).orElse("");
+        ApplicantStatus applicantStatus = ParserUtil.parseApplicantStatus(argMultimap
+                .getValue(PREFIX_STATUS).orElse(""));
 
-        return new AddApplicantStatusCommand(phone, new ApplicantStatus(status));
+        return new AddApplicantStatusCommand(phone, applicantStatus);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddInterviewerStatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddInterviewerStatusCommandParser.java
@@ -31,8 +31,9 @@ public class AddInterviewerStatusCommandParser implements Parser<AddInterviewerS
                     AddInterviewerStatusCommand.MESSAGE_USAGE), ive);
         }
 
-        String status = argMultimap.getValue(PREFIX_STATUS).orElse("");
+        InterviewerStatus interviewerStatus = ParserUtil.parseInterviewerStatus(argMultimap
+                .getValue(PREFIX_STATUS).orElse(""));
 
-        return new AddInterviewerStatusCommand(phone, new InterviewerStatus(status));
+        return new AddInterviewerStatusCommand(phone, interviewerStatus);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,7 +9,9 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.ApplicantStatus;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewerStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -104,5 +106,35 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String status} into a {@code ApplicantStatus}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code status} is invalid.
+     */
+    public static ApplicantStatus parseApplicantStatus(String applicantStatus) throws ParseException {
+        requireNonNull(applicantStatus);
+        String trimmedApplicantStatus = applicantStatus.trim();
+        if (!ApplicantStatus.isValidStatus(trimmedApplicantStatus)) {
+            throw new ParseException(ApplicantStatus.MESSAGE_CONSTRAINTS);
+        }
+        return new ApplicantStatus(trimmedApplicantStatus);
+    }
+
+    /**
+     * Parses a {@code String status} into a {@code InterviewerStatus}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code status} is invalid.
+     */
+    public static InterviewerStatus parseInterviewerStatus(String interviewerStatus) throws ParseException {
+        requireNonNull(interviewerStatus);
+        String trimmedInterviewerStatus = interviewerStatus.trim();
+        if (!InterviewerStatus.isValidStatus(trimmedInterviewerStatus)) {
+            throw new ParseException(InterviewerStatus.MESSAGE_CONSTRAINTS);
+        }
+        return new InterviewerStatus(trimmedInterviewerStatus);
     }
 }

--- a/src/main/java/seedu/address/model/person/ApplicantStatus.java
+++ b/src/main/java/seedu/address/model/person/ApplicantStatus.java
@@ -6,11 +6,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.model.person.enums.ApplicantState;
-
 /**
  * Represents an Applicant's status in the Tether.
- * Guarantee: is valid as declared in {@link #matchStatus(String, String)}
+ * Guarantee: is valid as declared in {@link #isValidStatus(String)}
  */
 public class ApplicantStatus extends Status {
 
@@ -27,13 +25,14 @@ public class ApplicantStatus extends Status {
      */
     public ApplicantStatus(String status) {
         requireNonNull(status);
-        value = matchStatus(status.toLowerCase(), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidStatus(status.toLowerCase()), MESSAGE_CONSTRAINTS);
+        value = status.toLowerCase();
     }
 
     /**
      * Checks and returns the status if it is valid.
      */
-    public String matchStatus(String status, String message) {
+    public static boolean isValidStatus(String status) {
         Pattern patternResumeReview = Pattern.compile("^resume review$");
         Matcher matcherResumeReview = patternResumeReview.matcher(status);
 
@@ -52,28 +51,13 @@ public class ApplicantStatus extends Status {
         Pattern patternRejected = Pattern.compile("^rejected$");
         Matcher matcherRejected = patternRejected.matcher(status.toLowerCase());
 
-        checkArgument((matcherResumeReview.matches()
+        return (matcherResumeReview.matches()
                         || matcherPendingIntv.matches()
                         || matcherCompletedIntv.matches()
                         || matcherWaitingList.matches()
                         || matcherAccepted.matches()
-                        || matcherRejected.matches()), message);
+                        || matcherRejected.matches());
 
-        ApplicantState state;
-        if (matcherResumeReview.matches()) {
-            state = ApplicantState.STAGEONE;
-        } else if (matcherPendingIntv.matches()) {
-            state = ApplicantState.STAGETWO;
-        } else if (matcherCompletedIntv.matches()) {
-            state = ApplicantState.STAGETHREE;
-        } else if (matcherWaitingList.matches()) {
-            state = ApplicantState.OUTCOMEONE;
-        } else if (matcherAccepted.matches()) {
-            state = ApplicantState.OUTCOMETWO;
-        } else {
-            state = ApplicantState.OUTCOMETHREE;
-        }
-        return state.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/InterviewerStatus.java
+++ b/src/main/java/seedu/address/model/person/InterviewerStatus.java
@@ -6,11 +6,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.model.person.enums.InterviewerState;
-
 /**
  * Represents an Interviewer's status in the Tether.
- * Guarantee: is valid as declared in {@link #matchStatus(String, String)}
+ * Guarantee: is valid as declared in {@link #isValidStatus(String)}
  */
 public class InterviewerStatus extends Status {
     public static final String MESSAGE_CONSTRAINTS =
@@ -25,28 +23,21 @@ public class InterviewerStatus extends Status {
      */
     public InterviewerStatus(String status) {
         requireNonNull(status);
-        value = matchStatus(status.toLowerCase(), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidStatus(status.toLowerCase()), MESSAGE_CONSTRAINTS);
+        value = status.toLowerCase();
     }
 
     /**
      * Checks and returns the status if it is valid.
      */
-    public String matchStatus(String status, String message) {
+    public static boolean isValidStatus(String status) {
         Pattern patternFree = Pattern.compile("^free$");
         Matcher matcherFree = patternFree.matcher(status);
 
         Pattern patternOccupied = Pattern.compile("^interview with .*");
         Matcher matcherOccupied = patternOccupied.matcher(status);
 
-        checkArgument((matcherFree.matches() || matcherOccupied.matches()), message);
-
-        InterviewerState state;
-        if (matcherFree.matches()) {
-            state = InterviewerState.FREE;
-        } else {
-            return status;
-        }
-        return state.toString();
+        return matcherFree.matches() || matcherOccupied.matches();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Status.java
+++ b/src/main/java/seedu/address/model/person/Status.java
@@ -3,6 +3,5 @@ package seedu.address.model.person;
 /**
  * Represents a Person's status in the Tether.
  */
-public abstract class Status {
-    public abstract String matchStatus(String status, String message);
+public class Status {
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.enums.Type;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -114,10 +115,10 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
-        if (type.equals("APPLICANT")) {
+        if (type.equals(Type.APPLICANT.toString())) {
             ApplicantStatus applicantStatus = new ApplicantStatus(status);
             return new Applicant(modelName, modelPhone, modelEmail, modelRemark, applicantStatus, modelTags);
-        } else if (type.equals("INTERVIEWER")) {
+        } else if (type.equals(Type.INTERVIEWER.toString())) {
             InterviewerStatus interviewerStatus = new InterviewerStatus(status);
             return new Interviewer(modelName, modelPhone, modelEmail, modelRemark, interviewerStatus, modelTags);
         }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -4,10 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_PERSON_NOT_IN_LIST;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_CUBE;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_CUBE;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_CUBE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
+import static seedu.address.testutil.TypicalPersons.CUBE;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
@@ -205,9 +209,9 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addInterviewerCommand = AddInterviewerPersonCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY;
-        Interviewer expectedPerson = new PersonBuilder(AMY).withTags().build_interviewer();
+        String addInterviewerCommand = AddInterviewerPersonCommand.COMMAND_WORD + NAME_DESC_CUBE + PHONE_DESC_CUBE
+                + EMAIL_DESC_CUBE;
+        Interviewer expectedPerson = new PersonBuilder(CUBE).withTags().build_interviewer();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);
         assertCommandFailure(addInterviewerCommand, CommandException.class, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/AddApplicantStatusCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApplicantStatusCommandTest.java
@@ -1,0 +1,101 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ApplicantStatus;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Remark;
+import seedu.address.testutil.PersonBuilder;
+
+public class AddApplicantStatusCommandTest {
+    private static final String APPLICANT_STATUS_STUB = "resume review";
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_addStatusUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withStatus(APPLICANT_STATUS_STUB).build_applicant();
+        AddApplicantStatusCommand addApplicantStatusCommand = new AddApplicantStatusCommand(firstPerson.getPhone(),
+                new ApplicantStatus(editedPerson.getStatus()));
+
+        String expectedMessage = String.format(AddApplicantStatusCommand.MESSAGE_ADD_STATUS_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(addApplicantStatusCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
+                .withStatus(APPLICANT_STATUS_STUB).build_applicant();
+
+        AddApplicantStatusCommand addApplicantStatusCommand = new AddApplicantStatusCommand(firstPerson.getPhone(),
+                new ApplicantStatus(editedPerson.getStatus()));
+
+        String expectedMessage = String.format(AddApplicantStatusCommand.MESSAGE_ADD_STATUS_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(addApplicantStatusCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonPhoneUnfilteredList_failure() {
+        AddApplicantStatusCommand addApplicantStatusCommand = new AddApplicantStatusCommand(new Phone("111"),
+                new ApplicantStatus(APPLICANT_STATUS_STUB));
+
+        assertCommandFailure(addApplicantStatusCommand, model, Messages.MESSAGE_INCORRECT_APPLICANT_PHONE_NUMBER);
+    }
+
+    @Test
+    public void equals() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        final AddApplicantStatusCommand standardCommand = new AddApplicantStatusCommand(firstPerson.getPhone(),
+                new ApplicantStatus(APPLICANT_STATUS_STUB));
+
+        // same values -> returns true
+        AddApplicantStatusCommand commandWithSameValues = new AddApplicantStatusCommand(firstPerson.getPhone(),
+                new ApplicantStatus(APPLICANT_STATUS_STUB));
+        assertEquals(standardCommand, commandWithSameValues);
+
+        // same object -> returns true
+        assertEquals(standardCommand, standardCommand);
+
+        // null -> returns false
+        assertNotEquals(null, standardCommand);
+
+        // different types -> returns false
+        assertNotEquals(standardCommand, new ClearCommand());
+
+        // different index -> returns false
+        assertNotEquals(standardCommand, new RemarkCommand(INDEX_SECOND_PERSON,
+                new Remark(VALID_REMARK_AMY)));
+
+        // different remark -> returns false
+        assertNotEquals(standardCommand, new RemarkCommand(INDEX_FIRST_PERSON,
+                new Remark(VALID_REMARK_BOB)));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddInterviewerStatusCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddInterviewerStatusCommandTest.java
@@ -1,0 +1,101 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_LAST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.InterviewerStatus;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.testutil.PersonBuilder;
+
+public class AddInterviewerStatusCommandTest {
+    private static final String INTERVIEWER_STATUS_STUB = "free";
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_addStatusUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_LAST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withStatus(INTERVIEWER_STATUS_STUB).build_interviewer();
+        AddInterviewerStatusCommand addInterviewerStatusCommand = new AddInterviewerStatusCommand(
+                firstPerson.getPhone(), new InterviewerStatus(editedPerson.getStatus()));
+
+        String expectedMessage = String.format(AddInterviewerStatusCommand.MESSAGE_ADD_STATUS_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(addInterviewerStatusCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showPersonAtIndex(model, INDEX_LAST_PERSON);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
+                .withStatus(INTERVIEWER_STATUS_STUB).build_interviewer();
+
+        AddInterviewerStatusCommand addInterviewerStatusCommand = new AddInterviewerStatusCommand(
+                firstPerson.getPhone(), new InterviewerStatus(editedPerson.getStatus()));
+
+        String expectedMessage = String.format(AddInterviewerStatusCommand.MESSAGE_ADD_STATUS_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(addInterviewerStatusCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonPhoneUnfilteredList_failure() {
+        AddInterviewerStatusCommand addInterviewerStatusCommand = new AddInterviewerStatusCommand(new Phone("111"),
+                new InterviewerStatus(INTERVIEWER_STATUS_STUB));
+
+        assertCommandFailure(addInterviewerStatusCommand, model, Messages.MESSAGE_INCORRECT_INTERVIEWER_PHONE_NUMBER);
+    }
+
+    @Test
+    public void equals() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+
+        final AddInterviewerStatusCommand standardCommand = new AddInterviewerStatusCommand(firstPerson.getPhone(),
+                new InterviewerStatus(INTERVIEWER_STATUS_STUB));
+
+        // same values -> returns true
+        AddInterviewerStatusCommand commandWithSameValues = new AddInterviewerStatusCommand(firstPerson.getPhone(),
+                new InterviewerStatus(INTERVIEWER_STATUS_STUB));
+        assertEquals(standardCommand, commandWithSameValues);
+
+        // same object -> returns true
+        assertEquals(standardCommand, standardCommand);
+
+        // null -> returns false
+        assertNotEquals(null, standardCommand);
+
+        // different types -> returns false
+        assertNotEquals(standardCommand, new ClearCommand());
+
+        // different index -> returns false
+        assertNotEquals(standardCommand, new AddInterviewerStatusCommand(secondPerson.getPhone(),
+                new InterviewerStatus(INTERVIEWER_STATUS_STUB)));
+
+        // different remark -> returns false
+        assertNotEquals(standardCommand, new AddInterviewerStatusCommand(secondPerson.getPhone(),
+                new InterviewerStatus(INTERVIEWER_STATUS_STUB)));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -28,10 +28,13 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
+    public static final String VALID_NAME_CUBE = "cube";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_CUBE = "87654321";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
+    public static final String VALID_EMAIL_CUBE = "cube@head.com";
     public static final String VALID_REMARK_AMY = "Like skiing.";
     public static final String VALID_REMARK_BOB = "Favourite pastime: Eating";
     public static final String VALID_TAG_HUSBAND = "husband";
@@ -39,10 +42,14 @@ public class CommandTestUtil {
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
+    public static final String NAME_DESC_CUBE = " " + PREFIX_NAME + VALID_NAME_CUBE;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
+    public static final String PHONE_DESC_CUBE = " " + PREFIX_PHONE + VALID_PHONE_CUBE;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
+
+    public static final String EMAIL_DESC_CUBE = " " + PREFIX_EMAIL + VALID_EMAIL_CUBE;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -78,6 +85,7 @@ public class CommandTestUtil {
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
+            System.out.println(ce);
             throw new AssertionError("Execution of command should not fail.", ce);
         }
     }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -36,7 +36,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Person editedPerson = new PersonBuilder().build();
+        Person editedPerson = new PersonBuilder().withStatus("resume review").build_applicant();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
@@ -55,7 +55,7 @@ public class EditCommandTest {
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_HUSBAND).build_interviewer();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
@@ -86,7 +86,7 @@ public class EditCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
+        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build_applicant();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 

--- a/src/test/java/seedu/address/logic/parser/AddApplicantStatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddApplicantStatusCommandParserTest.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddApplicantStatusCommand;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ApplicantStatus;
+import seedu.address.model.person.Person;
+
+public class AddApplicantStatusCommandParserTest {
+    private AddApplicantStatusCommandParser parser = new AddApplicantStatusCommandParser();
+    private final ApplicantStatus nonEmptyStatus = new ApplicantStatus("resume review");
+
+    @Test
+    public void parse_phoneSpecified_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String userInput = firstPerson.getPhone().value + " " + PREFIX_STATUS + nonEmptyStatus;
+        AddApplicantStatusCommand expectedCommand = new AddApplicantStatusCommand(firstPerson.getPhone(),
+                nonEmptyStatus);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_incompleteFields_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddApplicantStatusCommand.MESSAGE_USAGE);
+
+        // no parameters
+        assertParseFailure(parser, AddApplicantStatusCommand.COMMAND_WORD, expectedMessage);
+
+        // no phone
+        assertParseFailure(parser, AddApplicantStatusCommand.COMMAND_WORD + " " + nonEmptyStatus,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValues_failure() {
+        // invalid status
+        assertParseFailure(parser, VALID_PHONE_AMY + " " + PREFIX_STATUS + "nonsense",
+                ApplicantStatus.MESSAGE_CONSTRAINTS);
+
+        // invalid phone
+        assertParseFailure(parser, "1" + " " + PREFIX_STATUS + "resume review", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, AddApplicantStatusCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddInterviewerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddInterviewerCommandParserTest.java
@@ -1,16 +1,16 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_CUBE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_CUBE;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_CUBE;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
@@ -22,8 +22,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPersons.AMY;
-import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.CUBE;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,28 +40,28 @@ public class AddInterviewerCommandParserTest {
 
     @Test
     public void parse_interviewerAllFieldsPresent_success() {
-        Interviewer expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND).build_interviewer();
+        Interviewer expectedPerson = new PersonBuilder(CUBE).withTags(VALID_TAG_FRIEND).build_interviewer();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_CUBE + PHONE_DESC_CUBE + EMAIL_DESC_CUBE
                 + TAG_DESC_FRIEND, new AddInterviewerPersonCommand(expectedPerson));
 
         // all fields present
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+        assertParseSuccess(parser, NAME_DESC_CUBE + PHONE_DESC_CUBE + EMAIL_DESC_CUBE
                 + TAG_DESC_FRIEND, new AddInterviewerPersonCommand(expectedPerson));
 
         // multiple tags - all accepted
-        Interviewer expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+        Interviewer expectedPersonMultipleTags = new PersonBuilder(CUBE).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build_interviewer();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+        assertParseSuccess(parser, NAME_DESC_CUBE + PHONE_DESC_CUBE + EMAIL_DESC_CUBE
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddInterviewerPersonCommand(expectedPersonMultipleTags));
     }
 
     @Test
     public void parse_interviewerOptionalFieldsMissing_success() {
         // zero tags
-        Interviewer expectedPerson = new PersonBuilder(AMY).withTags().build_interviewer();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY,
+        Interviewer expectedPerson = new PersonBuilder(CUBE).withTags().build_interviewer();
+        assertParseSuccess(parser, NAME_DESC_CUBE + PHONE_DESC_CUBE + EMAIL_DESC_CUBE,
                 new AddInterviewerPersonCommand(expectedPerson));
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddInterviewerStatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddInterviewerStatusCommandParserTest.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddInterviewerStatusCommand;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.InterviewerStatus;
+import seedu.address.model.person.Person;
+
+public class AddInterviewerStatusCommandParserTest {
+
+    private AddInterviewerStatusCommandParser parser = new AddInterviewerStatusCommandParser();
+    private final InterviewerStatus nonEmptyStatus = new InterviewerStatus("free");
+
+    @Test
+    public void parse_phoneSpecified_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String userInput = firstPerson.getPhone().value + " " + PREFIX_STATUS + nonEmptyStatus;
+        AddInterviewerStatusCommand expectedCommand = new AddInterviewerStatusCommand(firstPerson.getPhone(),
+                nonEmptyStatus);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_incompleteFields_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddInterviewerStatusCommand.MESSAGE_USAGE);
+
+        // no parameters
+        assertParseFailure(parser, AddInterviewerStatusCommand.COMMAND_WORD, expectedMessage);
+
+        // no phone
+        assertParseFailure(parser, AddInterviewerStatusCommand.COMMAND_WORD + " " + nonEmptyStatus,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValues_failure() {
+        // invalid status
+        assertParseFailure(parser, VALID_PHONE_AMY + " " + PREFIX_STATUS + "nonsense",
+               InterviewerStatus.MESSAGE_CONSTRAINTS);
+
+        // invalid phone
+        assertParseFailure(parser, "1" + " " + PREFIX_STATUS + "free", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, AddInterviewerStatusCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -50,7 +50,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_add_interviewer() throws Exception {
-        Interviewer person = new PersonBuilder().build_interviewer();
+        Interviewer person = new PersonBuilder().withStatus("free").build_interviewer();
         AddInterviewerPersonCommand command = (AddInterviewerPersonCommand) parser.parseCommand(
                 PersonUtil.getAddInterviewerCommand(person));
         assertEquals(new AddInterviewerPersonCommand(person), command);

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -20,6 +20,7 @@ public class CommandParserTestUtil {
             Command command = parser.parse(userInput);
             assertEquals(expectedCommand, command);
         } catch (ParseException pe) {
+            System.out.println(pe.getMessage());
             throw new IllegalArgumentException("Invalid userInput.", pe);
         }
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -15,6 +15,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.enums.ApplicantState;
 import seedu.address.model.person.enums.Type;
 
 public class JsonAdaptedPersonTest {
@@ -41,7 +42,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_REMARK, VALID_TAGS,
-                        Type.APPLICANT.toString(), "resume review");
+                        Type.APPLICANT.toString(), ApplicantState.OUTCOMEONE.toString());
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -50,7 +51,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_REMARK, VALID_TAGS,
-                        Type.APPLICANT.toString(), "resume review");
+                        Type.APPLICANT.toString(), ApplicantState.OUTCOMEONE.toString());
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -59,7 +60,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_REMARK, VALID_TAGS,
-                        Type.APPLICANT.toString(), "resume review");
+                        Type.APPLICANT.toString(), ApplicantState.OUTCOMEONE.toString());
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -68,7 +69,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_REMARK, VALID_TAGS,
-                        Type.APPLICANT.toString(), "resume review");
+                        Type.APPLICANT.toString(), ApplicantState.OUTCOMEONE.toString());
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -77,7 +78,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_REMARK, VALID_TAGS,
-                        Type.APPLICANT.toString(), "resume review");
+                        Type.APPLICANT.toString(), ApplicantState.OUTCOMEONE.toString());
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,7 +87,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_REMARK, VALID_TAGS,
-                        Type.APPLICANT.toString(), "resume review");
+                        Type.APPLICANT.toString(), ApplicantState.OUTCOMEONE.toString());
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -97,7 +98,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_REMARK, invalidTags,
-                        Type.APPLICANT.toString(), "resume review");
+                        Type.APPLICANT.toString(), ApplicantState.OUTCOMEONE.toString());
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -12,9 +12,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
-import seedu.address.model.person.Status;
-import seedu.address.model.person.enums.ApplicantState;
-import seedu.address.model.person.enums.InterviewerState;
 import seedu.address.model.person.enums.Type;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
@@ -28,6 +25,7 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "alice@gmail.com";
     public static final String DEFAULT_REMARK = "She likes aardvarks.";
+    public static final String DEFAULT_STATUS = "resume review";
 
     private Name name;
     private Phone phone;
@@ -47,7 +45,7 @@ public class PersonBuilder {
         remark = new Remark(DEFAULT_REMARK);
         tags = new HashSet<>();
         type = Type.PERSON.toString();
-        status = "";
+        status = DEFAULT_STATUS;
     }
 
     /**
@@ -111,8 +109,8 @@ public class PersonBuilder {
     /**
      * Sets the {@code Status} of the {@code Person} that we are building.
      */
-    public PersonBuilder withStatus(Status status) {
-        this.status = status.toString();
+    public PersonBuilder withStatus(String status) {
+        this.status = status;
         return this;
     }
 
@@ -129,7 +127,7 @@ public class PersonBuilder {
      * {@code Email},{@code Remark}, {@code Status} and {@code Tags}.
      */
     public Applicant build_applicant() {
-        return new Applicant(name, phone, email, remark, new ApplicantStatus(ApplicantState.STAGEONE.toString()), tags);
+        return new Applicant(name, phone, email, remark, new ApplicantStatus(status), tags);
     }
 
     /**
@@ -137,7 +135,6 @@ public class PersonBuilder {
      * {@code Email},{@code Remark}, {@code Status} and {@code Tags}.
      */
     public Interviewer build_interviewer() {
-        return new Interviewer(name, phone, email, remark, new InterviewerStatus(InterviewerState.FREE.toString()),
-                tags);
+        return new Interviewer(name, phone, email, remark, new InterviewerStatus(status), tags);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,5 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_LAST_PERSON = Index.fromOneBased(9);
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,40 +26,40 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com")
             .withPhone("94351253").withRemark("She likes aardvarks.")
-            .withTags("Applicant", "friends").build();
+            .withStatus("resume review").withTags("Applicant", "friends").build_applicant();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withRemark("He can't take beer!")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("Applicant", "owesMoney", "friends").build();
+            .withTags("Applicant", "owesMoney", "friends").build_applicant();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withTags("Applicant").build();
+            .withEmail("heinz@example.com").withTags("Applicant").build_applicant();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withTags("Applicant", "friends").build();
+            .withEmail("cornelia@example.com").withTags("Applicant", "friends").build_applicant();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withTags("Applicant").build();
+            .withEmail("werner@example.com").withTags("Applicant").build_applicant();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withTags("Applicant").build();
+            .withEmail("lydia@example.com").withTags("Applicant").build_applicant();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withTags("Applicant").build();
+            .withEmail("anna@example.com").withTags("Applicant").build_applicant();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withTags("Applicant").build();
+            .withEmail("stefan@example.com").withTags("Applicant").build_applicant();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withTags("Applicant").build();
+            .withEmail("hans@example.com").withTags("Applicant").build_applicant();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withTags("Applicant", VALID_TAG_FRIEND).build();
+            .withEmail(VALID_EMAIL_AMY).withTags("Applicant", VALID_TAG_FRIEND).build_applicant();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withTags("Applicant", VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .build();
+            .build_applicant();
 
     public static final Applicant HEAD = new PersonBuilder().withName("head").withPhone("12345678")
             .withEmail("head@cube.com").withTags("Applicant").build_applicant();
 
     public static final Interviewer CUBE = new PersonBuilder().withName("cube").withPhone("87654321")
-            .withEmail("cube@head.com").withTags("Interviewer").build_interviewer();
+            .withEmail("cube@head.com").withTags("Interviewer").withStatus("free").build_interviewer();
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
     private TypicalPersons() {} // prevents instantiation


### PR DESCRIPTION
Modified status implementation from [previous commit](https://github.com/nus-cs2103-AY2324S2/tp/commit/d2af4beae45d563adbb94902f4f469aceb9f8995) by:
- Making `isValidStatus` in `ApplicantStatus` and `InterviewerStatus` more consistent with `Phone`, `Remark`, etc types
- Making `AddApplicantStatusCommandParser` and `AddInterviewerStatusCommandParser` implementation more consistent with `Applicant` etc types