### PR TITLE
Fix remark bug, touch up cosmetics for dg and application

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -178,7 +178,7 @@ The above `execute` operations utilise `ModelManager#updateFilteredPersonList()`
 
 The following class diagram summarizes the organisation of the `FindCommand` variant classes.
 
-<puml src="diagrams/find/FindCommandClass.puml" alt="FindCommandClassDiagram" width="550"/>
+<puml src="diagrams/find/FindCommandClass.puml" alt="FindCommandClassDiagram"/>
 
 Given below is an example usage scenario and how the find mechanism behaves at each step. All 3 variants behave in the same way, just with their keywords being of different types.
 
@@ -199,7 +199,7 @@ Step 2. The user executes `find_name` command to find a person with the name Rya
 <br>
 The following sequence diagram shows how a find operation, specifically `find_name`, goes through the `Logic` component. `find_phone` and `find_email` also behave in a similar way.
 
-<puml src="diagrams/FindSequenceDiagram-Logic.puml" alt="FindSequenceDiagram-Logic" width="550"/>
+<puml src="diagrams/find/FindSequenceDiagram-Logic.puml" alt="FindSequenceDiagram-Logic"/>
 
 
 #### Design considerations:
@@ -233,7 +233,7 @@ The applicant/interviewer status mechanism is facilitated by `AddApplicantStatus
 
 The following class diagram shows the structure of `AddApplicantStatusCommand`, `AddInterviewerStatusCommand`, `ApplicantStatus`, `InterviewerStatus`:
 
-<puml src="diagrams/add-status/StatusCommandClasses.puml" width="250"/>
+<puml src="diagrams/add-status/StatusCommandClasses.puml"/>
 
 Given below is an example usage scenario and how the applicant/interviewer status mechanism behaves at each step.
 
@@ -259,7 +259,7 @@ Step 4. The user now decides that she wants to edit `Yash`'s status to "complete
 
 The following sequence diagram illustrates step 4:
 
-<puml src="diagrams/add-status/StatusCommandSequence.puml" width="250"/>
+<puml src="diagrams/add-status/StatusCommandSequence.puml"/>
 
 #### Design considerations:
 

--- a/src/main/java/seedu/address/logic/commands/AddApplicantStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApplicantStatusCommand.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.Applicant;
 import seedu.address.model.person.ApplicantStatus;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.enums.Type;
 
 /**
  * Parses input arguments and creates a new AddApplicantCommandStatus object
@@ -63,7 +64,7 @@ public class AddApplicantStatusCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INCORRECT_APPLICANT_PHONE_NUMBER);
         }
 
-        if (!personToEdit.getPersonType().equals("APPLICANT")) {
+        if (!personToEdit.getPersonType().equals(Type.APPLICANT.toString())) {
             throw new CommandException(Messages.MESSAGE_INCORRECT_STATUS_APPLICANT);
         }
 

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -5,13 +5,23 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Applicant;
+import seedu.address.model.person.ApplicantStatus;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Interviewer;
+import seedu.address.model.person.InterviewerStatus;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.enums.Type;
+import seedu.address.model.tag.Tag;
 
 /**
  * Changes the remark of an existing person in the address book.
@@ -53,8 +63,21 @@ public class RemarkCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
-                remark, personToEdit.getTags());
+        Name name = personToEdit.getName();
+        Phone phone = personToEdit.getPhone();
+        Email email = personToEdit.getEmail();
+        Set<Tag> tags = personToEdit.getTags();
+        String type = personToEdit.getPersonType();
+        String status = personToEdit.getCurrentStatus();
+
+        Person editedPerson;
+        if (type.equals(Type.APPLICANT.toString())) {
+            editedPerson = new Applicant(name, phone, email, remark, new ApplicantStatus(status), tags);
+        } else if (type.equals(Type.INTERVIEWER.toString())) {
+            editedPerson = new Interviewer(name, phone, email, remark, new InterviewerStatus(status), tags);
+        } else {
+            editedPerson = new Person(name, phone, email, remark, tags);
+        }
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/ui/InterviewCard.java
+++ b/src/main/java/seedu/address/ui/InterviewCard.java
@@ -46,11 +46,11 @@ public class InterviewCard extends UiPart<Region> {
         super(FXML);
         this.interview = interview;
         id.setText(displayedIndex + ". ");
-        applicantNamePhone.setText("Applicant:   " + interview.getApplicant().getName().toString());
+        applicantNamePhone.setText("Interview with " + interview.getApplicant().getName().toString());
         interviewerNamePhone.setText("Interviewer: " + interview.getInterviewer().getName().toString());
-        date.setText(interview.getDate().toString());
-        startEndTime.setText(interview.getStartTime().toString() + " ~ " + interview.getEndTime().toString());
-        description.setText(interview.getDescription());
+        date.setText("Date: " + interview.getDate().toString());
+        startEndTime.setText(interview.getStartTime().toString() + "-" + interview.getEndTime().toString());
+        description.setText("Description: " + interview.getDescription());
     }
 
     @Override

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -15,6 +15,13 @@
     -fx-background-color: black;
 }
 
+.list-header {
+    -fx-font-size: 20pt;
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: white;
+    -fx-opacity: 1;
+}
+
 .label {
     -fx-font-size: 11pt;
     -fx-font-family: "Segoe UI Semibold";

--- a/src/main/resources/view/InterviewListCard.fxml
+++ b/src/main/resources/view/InterviewListCard.fxml
@@ -3,45 +3,41 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
-   <VBox prefHeight="140.0" prefWidth="66.0">
-      <children>
-             <Label fx:id="id" prefHeight="106.0" prefWidth="93.0" style="-fx-font-size: 30;" styleClass="cell_big_label" text="\$id" translateX="10.0">
-                 <minWidth>
-                     <!-- Ensures that the label text is never truncated -->
-                     <Region fx:constant="USE_PREF_SIZE" />
-                 </minWidth>
-             </Label>
-      </children>
-   </VBox>
-    <GridPane prefHeight="140.0" prefWidth="372.0" HBox.hgrow="ALWAYS">
+<HBox id="cardPane" fx:id="cardPane" prefHeight="151.0" prefWidth="205.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane prefHeight="139.0" prefWidth="205.0" HBox.hgrow="ALWAYS">
         <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="150" />
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
         </columnConstraints>
-        <VBox alignment="CENTER_LEFT" minHeight="105" prefHeight="139.0" prefWidth="372.0" GridPane.columnIndex="0">
+        <VBox alignment="CENTER_LEFT" minHeight="105" prefHeight="154.0" prefWidth="205.0" GridPane.columnIndex="0">
             <padding>
                 <Insets bottom="5" left="15" right="5" top="5" />
             </padding>
             <HBox alignment="CENTER_LEFT" spacing="5">
-                <Label fx:id="applicantNamePhone" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="27.0" prefWidth="352.0" style="-fx-font-size: 22;" styleClass="cell_big_label" text="\$applicantNamePhone" wrapText="true" />
+                <Label fx:id="id" style="-fx-font-size: 30;" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="applicantNamePhone" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="27.0" prefWidth="352.0" style="-fx-font-size: 30;" styleClass="cell_big_label" text="\$applicantNamePhone" wrapText="true" />
             </HBox>
-         <HBox alignment="CENTER_LEFT" layoutX="25.0" layoutY="15.0" spacing="5">
-            <children>
-               <Label fx:id="interviewerNamePhone" layoutX="15.0" layoutY="10.0" prefHeight="17.0" prefWidth="357.0" style="-fx-font-size: 22;" styleClass="cell_big_label" text="\$interviewerNamePhone" wrapText="true" />
-            </children>
-         </HBox>
+            <FlowPane fx:id="tags" />
+            <FlowPane fx:id="status" />
+            <Label fx:id="interviewerNamePhone" layoutX="15.0" layoutY="10.0" prefHeight="17.0" prefWidth="357.0" style="-fx-font-size: 18;" styleClass="cell_big_label" text="\$interviewerNamePhone" wrapText="true" />
             <Label fx:id="date" prefHeight="17.0" prefWidth="306.0" style="-fx-font-size: 18;" styleClass="cell_small_label" text="\$date" />
             <Label fx:id="startEndTime" prefHeight="17.0" prefWidth="307.0" style="-fx-font-size: 18;" styleClass="cell_small_label" text="\$startEndTime" />
-         <Label fx:id="description" layoutX="25.0" layoutY="80.0" prefHeight="7.0" prefWidth="346.0" style="-fx-font-size: 18;" styleClass="cell_small_label" text="description" />
+            <Label fx:id="description" layoutX="25.0" layoutY="80.0" prefHeight="7.0" prefWidth="346.0" style="-fx-font-size: 18;" styleClass="cell_small_label" text="description" />
         </VBox>
-      <rowConstraints>
-         <RowConstraints />
-      </rowConstraints>
+        <rowConstraints>
+            <RowConstraints />
+        </rowConstraints>
     </GridPane>
 </HBox>
+

--- a/src/main/resources/view/InterviewListPanel.fxml
+++ b/src/main/resources/view/InterviewListPanel.fxml
@@ -3,6 +3,14 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.Label?>
+<?import java.net.URL?>
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <stylesheets>
+        <URL value="@DarkTheme.css" />
+    </stylesheets>
+    <VBox>
+        <Label styleClass="label-header" style="-fx-font-size: 22; -fx-text-alignment: center;">Upcoming Interviews</Label>
+    </VBox>
     <ListView fx:id="interviewListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -11,6 +11,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
+<?import javafx.scene.control.Label?>
 <fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Tether" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
     <scene>
         <Scene>
@@ -42,7 +43,7 @@
                 </StackPane>
                 <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="340.0" VBox.vgrow="ALWAYS">
                     <children>
-
+                        <Label text="hello"/>
                         <VBox fx:id="personList" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="340.0" style="-fx-background-color: #012A4A;" styleClass="pane-with-border" HBox.hgrow="ALWAYS">
                             <padding>
                                 <Insets bottom="10" left="10" right="10" top="10" />

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -3,6 +3,14 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.Label?>
+<?import java.net.URL?>
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <stylesheets>
+    <URL value="@DarkTheme.css" />
+  </stylesheets>
+  <VBox>
+    <Label styleClass="label-header" style="-fx-font-size: 22; -fx-text-alignment: center;">Persons</Label>
+  </VBox>
   <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
@@ -35,7 +35,7 @@ public class RemarkCommandTest {
     @Test
     public void execute_addRemarkUnfilteredList_success() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(firstPerson).withRemark(REMARK_STUB).build();
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark(REMARK_STUB).build_applicant();
 
         RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(editedPerson.getRemark().value));
 
@@ -50,7 +50,7 @@ public class RemarkCommandTest {
     @Test
     public void execute_deleteRemarkUnfilteredList_success() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(firstPerson).withRemark("").build();
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark("").build_applicant();
 
         RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON,
                 new Remark(editedPerson.getRemark().toString()));
@@ -69,7 +69,7 @@ public class RemarkCommandTest {
 
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
-                .withRemark(REMARK_STUB).build();
+                .withRemark(REMARK_STUB).build_applicant();
 
         RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(editedPerson.getRemark().value));
 


### PR DESCRIPTION
Fix remark bug
- When adding a remark to a person, status is lost since the `RemarkCommand` creates a new `Person` out of the person to be edited and thus the old status is overriden

Cosmetics (DG)
- Remove width parameters from uml diagrams
- Add `/find/` in find-command sequence diagram path

Cosmetics (App)
- Align interview details to the left
- Add headers on top describing the two lists

     - <img width="500" alt="image" src="https://github.com/AY2324S2-CS2103T-F11-3/tp/assets/105275750/d8eaf759-f0da-44d3-8128-a5df5fe559e2">

