### PR TITLE
Status patches [READ DESCRIPTION FOR PATCH NOTES]

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddApplicantStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApplicantStatusCommand.java
@@ -26,10 +26,10 @@ public class AddApplicantStatusCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the status of the applicant identified "
             + "by the phone number used in the command. "
             + "Existing status will be overwritten by the input.\n"
-            + "Parameters: PHONE (must be at least 3 digits) "
-            + PREFIX_STATUS + "(must be either \"resume review\", \"pending interview\", \"completed interview\""
-            + "\"waiting list\", \"accepted\", or \"rejected\") [STATUS]\n"
-            + "Example: " + COMMAND_WORD + " 98362254 "
+            + "Parameters: [phone] (must be an existing valid phone) "
+            + PREFIX_STATUS + "[status] (must be one of \"resume review\", \"pending interview\", "
+            + "\"completed interview\", \"waiting list\", \"accepted\", or \"rejected\")\n"
+            + "Example usage: " + COMMAND_WORD + " 98362254 "
             + PREFIX_STATUS + "accepted";
 
     public static final String MESSAGE_ADD_STATUS_SUCCESS = "Added status to Applicant: %1$s";

--- a/src/main/java/seedu/address/logic/commands/AddInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInterviewCommand.java
@@ -144,8 +144,8 @@ public class AddInterviewCommand extends Command {
 
         model.addInterview(interview);
         model.sortInterview();
-        applicantSearch.updateCurrentStatusToReflectInterview(model);
-        interviewerSearch.updateCurrentStatusToReflectInterview(model, applicantSearch);
+        applicantSearch.updateCurrentStatusToReflectScheduledInterview(model);
+        interviewerSearch.updateCurrentStatusToReflectScheduledInterview(model, applicantSearch);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, "\n" + Messages.formatInterview(interview)));
     }

--- a/src/main/java/seedu/address/logic/commands/AddInterviewerStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInterviewerStatusCommand.java
@@ -25,9 +25,9 @@ public class AddInterviewerStatusCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the status of the interviewer identified "
             + "by the phone number used in the command. "
             + "Existing status will be overwritten by the input.\n"
-            + "Parameters: PHONE (must be at least 3 digits) "
-            + PREFIX_STATUS + "(must be either \"free\" or \"interview with [APPLICANT NAME]\") [STATUS]\n"
-            + "Example: " + COMMAND_WORD + " 98362254 "
+            + "Parameters: [phone] (must be an existing valid phone) "
+            + PREFIX_STATUS + "[status] (must be either \"free\" or \"interview with [APPLICANT NAME]\")\n"
+            + "Example usage: " + COMMAND_WORD + " 98362254 "
             + PREFIX_STATUS + "free";
 
     public static final String MESSAGE_ADD_STATUS_SUCCESS = "Added status to Interviewer: %1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteInterviewCommand.java
@@ -25,7 +25,7 @@ public class DeleteInterviewCommand extends Command {
 
     public static final String MESSAGE_DELETE_INTERVIEW_SUCCESS = "Interview Deleted ";
 
-    private Integer targetInt;
+    private final Integer targetInt;
 
 
     public DeleteInterviewCommand(int targetInt) {
@@ -40,16 +40,15 @@ public class DeleteInterviewCommand extends Command {
         try {
             interview = lastShownList.get(targetInt);
         } catch (IndexOutOfBoundsException e) {
-            System.out.println("index wrong");
             throw new CommandException(Messages.MESSAGE_INTERVIEW_NOT_IN_LIST);
         }
 
         model.deleteInterview(interview);
         interview.getApplicant().revertCurrentStatus(model);
-        interview.getInterviewer().updateCurrentStatusToReflectInterview(model);
+        interview.getInterviewer().updateCurrentStatusToReflectInterview(model, targetInt);
 
         return new CommandResult(MESSAGE_DELETE_INTERVIEW_SUCCESS
-                + "\nInformation about delete interview: \n" + Messages.formatInterview(interview));
+                + "\nInformation about deleted interview: \n" + Messages.formatInterview(interview));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteInterviewCommand.java
@@ -43,9 +43,9 @@ public class DeleteInterviewCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INTERVIEW_NOT_IN_LIST);
         }
 
-        model.deleteInterview(interview);
         interview.getApplicant().revertCurrentStatus(model);
-        interview.getInterviewer().updateCurrentStatusToReflectInterview(model, targetInt);
+        interview.getInterviewer().updateCurrentStatusToReflectDeletedInterview(model, interview.getApplicant());
+        model.deleteInterview(interview);
 
         return new CommandResult(MESSAGE_DELETE_INTERVIEW_SUCCESS
                 + "\nInformation about deleted interview: \n" + Messages.formatInterview(interview));

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -27,8 +27,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
-import seedu.address.model.person.enums.ApplicantState;
-import seedu.address.model.person.enums.InterviewerState;
 import seedu.address.model.person.enums.Type;
 import seedu.address.model.tag.Tag;
 
@@ -103,12 +101,13 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Remark updatedRemark = personToEdit.getRemark(); // edit command does not allow editing remarks
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        String status = editPersonDescriptor.getStatus().orElse(personToEdit.getCurrentStatus());
         if (personToEdit.getPersonType().equals(Type.APPLICANT.toString())) {
             return new Applicant(updatedName, updatedPhone, updatedEmail, updatedRemark,
-                    new ApplicantStatus(ApplicantState.STAGE_ONE.toString()), updatedTags);
+                    new ApplicantStatus(status), updatedTags);
         } else if (personToEdit.getPersonType().equals(Type.INTERVIEWER.toString())) {
             return new Interviewer(updatedName, updatedPhone, updatedEmail, updatedRemark,
-                    new InterviewerStatus(InterviewerState.FREE.toString()), updatedTags);
+                    new InterviewerStatus(status), updatedTags);
         }
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedRemark, updatedTags);
@@ -142,6 +141,8 @@ public class EditCommand extends Command {
         private Email email;
         private Set<Tag> tags;
 
+        private String status;
+
         public EditPersonDescriptor() {}
 
         /**
@@ -153,6 +154,7 @@ public class EditCommand extends Command {
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setTags(toCopy.tags);
+            setStatus(toCopy.status);
         }
 
         /**
@@ -201,6 +203,14 @@ public class EditCommand extends Command {
          */
         public Optional<Set<Tag>> getTags() {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public Optional<String> getStatus() {
+            return Optional.ofNullable(status);
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/parser/DeleteInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteInterviewCommandParser.java
@@ -17,7 +17,7 @@ public class DeleteInterviewCommandParser implements Parser<DeleteInterviewComma
      */
     public DeleteInterviewCommand parse(String args) throws ParseException {
         try {
-            Integer x = Integer.valueOf(args.trim());
+            int x = Integer.parseInt(args.trim());
             x -= 1;
             return new DeleteInterviewCommand(x);
         } catch (NumberFormatException e) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -135,6 +135,11 @@ public class ParserUtil {
         if (!InterviewerStatus.isValidStatus(trimmedInterviewerStatus)) {
             throw new ParseException(InterviewerStatus.MESSAGE_CONSTRAINTS);
         }
-        return new InterviewerStatus(trimmedInterviewerStatus);
+        String[] newlineSeparatedStatusArray = trimmedInterviewerStatus.split("\n");
+        StringBuilder newlineSeparatedStatus = new StringBuilder();
+        for (String individualStatus : newlineSeparatedStatusArray) {
+            newlineSeparatedStatus.append(individualStatus);
+        }
+        return new InterviewerStatus(newlineSeparatedStatus.toString());
     }
 }

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -85,11 +85,8 @@ public class Interview {
 
         boolean applicantMatch = otherInterview.applicant.equals(this.applicant);
         boolean interviewerMatch = otherInterview.interviewer.equals(this.interviewer);
-        boolean dateMatch = otherInterview.date.equals(this.date);
-        boolean timeMatch = otherInterview.startTime.equals(this.startTime)
-                && otherInterview.endTime.equals(this.endTime);
 
-        return applicantMatch && interviewerMatch && dateMatch && timeMatch;
+        return applicantMatch && interviewerMatch;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Applicant.java
+++ b/src/main/java/seedu/address/model/person/Applicant.java
@@ -42,7 +42,7 @@ public class Applicant extends Person {
      * @param model the location of the applicant to be edited
      */
     @Override
-    public void updateCurrentStatusToReflectInterview(Model model) {
+    public void updateCurrentStatusToReflectScheduledInterview(Model model) {
         previousStatus = currentStatus;
         currentStatus = new ApplicantStatus(ApplicantState.STAGE_TWO.toString());
         /*
@@ -59,7 +59,9 @@ public class Applicant extends Person {
      */
     @Override
     public void revertCurrentStatus(Model model) {
-        currentStatus = previousStatus;
+        currentStatus = previousStatus == null
+                        ? new ApplicantStatus(ApplicantState.STAGE_ONE.toString())
+                        : previousStatus;
         /*
             Need to find this applicant by reference equality and replace them for the change in status to reflect in
             the gui immediately

--- a/src/main/java/seedu/address/model/person/ApplicantStatus.java
+++ b/src/main/java/seedu/address/model/person/ApplicantStatus.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 public class ApplicantStatus extends Status {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Status can only be one of \"resume review\", \"pending interview\", \"completed interview\"\n"
+            "Applicants status can only be one of \"resume review\", \"pending interview\", \"completed interview\","
                     + "\"waiting list\", \"accepted\", or \"rejected\"";
 
     public final String value;

--- a/src/main/java/seedu/address/model/person/Interviewer.java
+++ b/src/main/java/seedu/address/model/person/Interviewer.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import seedu.address.model.Model;
@@ -15,7 +17,7 @@ public class Interviewer extends Person {
 
     private final Type type = Type.INTERVIEWER;
 
-    private InterviewerStatus status;
+    private final List<InterviewerStatus> upcomingInterviews = new ArrayList<>();
 
     /**
      * Every field must be present and not null.
@@ -23,7 +25,9 @@ public class Interviewer extends Person {
     public Interviewer(Name name, Phone phone, Email email, Remark remark, InterviewerStatus status, Set<Tag> tags) {
         super(name, phone, email, remark, tags);
         this.tags.add(new Tag("Interviewer"));
-        this.status = status;
+        if (!status.value.equals(InterviewerState.FREE.toString())) {
+            upcomingInterviews.add(status);
+        }
     }
 
     @Override
@@ -36,18 +40,14 @@ public class Interviewer extends Person {
      *
      * @param model the location of the interviewer to be edited.
      */
-    public void updateCurrentStatusToReflectInterview(Model model) {
-        if (status.value.contains(InterviewerState.OCCUPIED.toString())) {
-            status = new InterviewerStatus(InterviewerState.FREE.toString());
-        }
-
+    public void updateCurrentStatusToReflectInterview(Model model, int interviewIndex) {
+        upcomingInterviews.remove(interviewIndex);
         /*
-            Need to find this interviewer by reference equality and replace them for the change in status to reflect
-            in the gui immediately
+         * Need to find this interviewer by reference equality and replace them for the change in status to reflect
+         * in the gui immediately
          */
         model.setPerson(this, this);
     }
-
 
     /**
      * Changes the status of this interviewer to interview with [applicant name] only if the status is free currently.
@@ -56,10 +56,7 @@ public class Interviewer extends Person {
      * @param applicantScheduled the applicant whom this interviewer is scheduled with.
      */
     public void updateCurrentStatusToReflectInterview(Model model, Person applicantScheduled) {
-        if (status.value.equals(InterviewerState.FREE.toString())) {
-            status = new InterviewerStatus(InterviewerState.OCCUPIED + " " + applicantScheduled.getName());
-        }
-
+        upcomingInterviews.add(new InterviewerStatus(InterviewerState.OCCUPIED + " " + applicantScheduled.getName()));
         /*
             Need to find this interviewer by reference equality and replace them for the change in status to reflect
             in the gui immediately
@@ -69,7 +66,25 @@ public class Interviewer extends Person {
 
     @Override
     public String getCurrentStatus() {
-        return status.toString();
+        if (upcomingInterviews.isEmpty()) {
+            return InterviewerState.FREE.toString();
+        } else {
+            System.out.println(stringifyInterviewStatuses());
+            return stringifyInterviewStatuses();
+        }
+    }
+
+    private String stringifyInterviewStatuses() {
+        StringBuilder interviewStatusesString = new StringBuilder();
+        int numberOfScheduledInterviews = upcomingInterviews.size();
+        for (int i = 0; i < numberOfScheduledInterviews; i++) {
+            if (i == numberOfScheduledInterviews - 1) {
+                interviewStatusesString.append(upcomingInterviews.get(i));
+            } else {
+                interviewStatusesString.append(upcomingInterviews.get(i)).append(",\n");
+            }
+        }
+        return interviewStatusesString.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Interviewer.java
+++ b/src/main/java/seedu/address/model/person/Interviewer.java
@@ -27,20 +27,13 @@ public class Interviewer extends Person {
         super(name, phone, email, remark, tags);
         this.tags.add(new Tag("Interviewer"));
         if (!status.value.equals(InterviewerState.FREE.toString())) {
-            splitAndAdd(status);
+            upcomingInterviews.add(status);
         }
     }
 
     @Override
     public String getPersonType() {
         return type.toString();
-    }
-
-    private void splitAndAdd(InterviewerStatus status) {
-        String[] newlineSeparatedStatus = status.value.split("\n");
-        for (String individualStatus : newlineSeparatedStatus) {
-            upcomingInterviews.add(new InterviewerStatus(individualStatus));
-        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Interviewer.java
+++ b/src/main/java/seedu/address/model/person/Interviewer.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -26,7 +27,7 @@ public class Interviewer extends Person {
         super(name, phone, email, remark, tags);
         this.tags.add(new Tag("Interviewer"));
         if (!status.value.equals(InterviewerState.FREE.toString())) {
-            upcomingInterviews.add(status);
+            splitAndAdd(status);
         }
     }
 
@@ -35,13 +36,26 @@ public class Interviewer extends Person {
         return type.toString();
     }
 
+    private void splitAndAdd(InterviewerStatus status) {
+        String[] newlineSeparatedStatus = status.value.split("\n");
+        for (String individualStatus : newlineSeparatedStatus) {
+            upcomingInterviews.add(new InterviewerStatus(individualStatus));
+        }
+    }
+
     /**
      * Changes the status of this interviewer to free only if they had an interview before.
      *
      * @param model the location of the interviewer to be edited.
      */
-    public void updateCurrentStatusToReflectInterview(Model model, int interviewIndex) {
-        upcomingInterviews.remove(interviewIndex);
+    public void updateCurrentStatusToReflectDeletedInterview(Model model, Person applicantScheduled) {
+        String scheduledApplicantName = applicantScheduled.getName().toString().toLowerCase();
+        for (Iterator<InterviewerStatus> iterator = upcomingInterviews.iterator(); iterator.hasNext();) {
+            String status = iterator.next().toString();
+            if (status.contains(scheduledApplicantName)) {
+                iterator.remove();
+            }
+        }
         /*
          * Need to find this interviewer by reference equality and replace them for the change in status to reflect
          * in the gui immediately
@@ -55,7 +69,7 @@ public class Interviewer extends Person {
      * @param model the location of the interviewer to be edited.
      * @param applicantScheduled the applicant whom this interviewer is scheduled with.
      */
-    public void updateCurrentStatusToReflectInterview(Model model, Person applicantScheduled) {
+    public void updateCurrentStatusToReflectScheduledInterview(Model model, Person applicantScheduled) {
         upcomingInterviews.add(new InterviewerStatus(InterviewerState.OCCUPIED + " " + applicantScheduled.getName()));
         /*
             Need to find this interviewer by reference equality and replace them for the change in status to reflect
@@ -69,7 +83,6 @@ public class Interviewer extends Person {
         if (upcomingInterviews.isEmpty()) {
             return InterviewerState.FREE.toString();
         } else {
-            System.out.println(stringifyInterviewStatuses());
             return stringifyInterviewStatuses();
         }
     }
@@ -81,7 +94,7 @@ public class Interviewer extends Person {
             if (i == numberOfScheduledInterviews - 1) {
                 interviewStatusesString.append(upcomingInterviews.get(i));
             } else {
-                interviewStatusesString.append(upcomingInterviews.get(i)).append(",\n");
+                interviewStatusesString.append(upcomingInterviews.get(i)).append("\n");
             }
         }
         return interviewStatusesString.toString();

--- a/src/main/java/seedu/address/model/person/InterviewerStatus.java
+++ b/src/main/java/seedu/address/model/person/InterviewerStatus.java
@@ -24,7 +24,7 @@ public class InterviewerStatus extends Status {
     public InterviewerStatus(String status) {
         requireNonNull(status);
         checkArgument(isValidStatus(status.toLowerCase()), MESSAGE_CONSTRAINTS);
-        value = status.toLowerCase();
+        value = splitByNewLine(status.toLowerCase());
     }
 
     /**
@@ -38,6 +38,15 @@ public class InterviewerStatus extends Status {
         Matcher matcherOccupied = patternOccupied.matcher(status);
 
         return matcherFree.matches() || matcherOccupied.matches();
+    }
+
+    private String splitByNewLine(String status) {
+        String[] newlineSeparatedStatusArray = status.split("\n");
+        StringBuilder newlineSeparatedStatus = new StringBuilder();
+        for (String individualStatus : newlineSeparatedStatusArray) {
+            newlineSeparatedStatus.append(individualStatus);
+        }
+        return newlineSeparatedStatus.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/InterviewerStatus.java
+++ b/src/main/java/seedu/address/model/person/InterviewerStatus.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
  */
 public class InterviewerStatus extends Status {
     public static final String MESSAGE_CONSTRAINTS =
-            "Status can only be either \"free\" or \"interview with [APPLICANT NAME]\"";
+            "Interviewer status can only be either \"free\" or \"interview with [applicant name]\"";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/InterviewerStatus.java
+++ b/src/main/java/seedu/address/model/person/InterviewerStatus.java
@@ -34,7 +34,7 @@ public class InterviewerStatus extends Status {
         Pattern patternFree = Pattern.compile("^free$");
         Matcher matcherFree = patternFree.matcher(status);
 
-        Pattern patternOccupied = Pattern.compile("^interview with .*");
+        Pattern patternOccupied = Pattern.compile("(?s)^interview with .*");
         Matcher matcherOccupied = patternOccupied.matcher(status);
 
         return matcherFree.matches() || matcherOccupied.matches();

--- a/src/main/java/seedu/address/model/person/InterviewerStatus.java
+++ b/src/main/java/seedu/address/model/person/InterviewerStatus.java
@@ -24,7 +24,7 @@ public class InterviewerStatus extends Status {
     public InterviewerStatus(String status) {
         requireNonNull(status);
         checkArgument(isValidStatus(status.toLowerCase()), MESSAGE_CONSTRAINTS);
-        value = splitByNewLine(status.toLowerCase());
+        value = status.toLowerCase();
     }
 
     /**
@@ -38,15 +38,6 @@ public class InterviewerStatus extends Status {
         Matcher matcherOccupied = patternOccupied.matcher(status);
 
         return matcherFree.matches() || matcherOccupied.matches();
-    }
-
-    private String splitByNewLine(String status) {
-        String[] newlineSeparatedStatusArray = status.split("\n");
-        StringBuilder newlineSeparatedStatus = new StringBuilder();
-        for (String individualStatus : newlineSeparatedStatusArray) {
-            newlineSeparatedStatus.append(individualStatus);
-        }
-        return newlineSeparatedStatus.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -69,15 +69,16 @@ public class Person {
         return type.toString();
     }
 
-    public void updateCurrentStatusToReflectInterview(Model model) {}
-
-    public void updateCurrentStatusToReflectInterview(Model model, int interviewIndex) {
-    }
-
-    public void updateCurrentStatusToReflectInterview(Model model, Person applicantScheduled) {
-    }
-
     public void revertCurrentStatus(Model model) {
+    }
+
+    public void updateCurrentStatusToReflectDeletedInterview(Model model, Person applicantScheduled) {
+    }
+
+    public void updateCurrentStatusToReflectScheduledInterview(Model model) {
+    }
+
+    public void updateCurrentStatusToReflectScheduledInterview(Model model, Person applicantScheduled) {
     }
 
     public String getCurrentStatus() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -27,7 +27,7 @@ public class Person {
     private final Remark remark;
 
     // Type field
-    private Type type = Type.PERSON;
+    private final Type type = Type.PERSON;
 
     /**
      * Every field must be present and not null.
@@ -70,6 +70,9 @@ public class Person {
     }
 
     public void updateCurrentStatusToReflectInterview(Model model) {}
+
+    public void updateCurrentStatusToReflectInterview(Model model, int interviewIndex) {
+    }
 
     public void updateCurrentStatusToReflectInterview(Model model, Person applicantScheduled) {
     }
@@ -136,5 +139,4 @@ public class Person {
         getTags().forEach(builder::append);
         return builder.toString();
     }
-
 }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -26,8 +26,10 @@ public class HelpWindow extends UiPart<Stage> {
             + "\n5. List applicants/interviewers: list_persons"
             + "\n6. List interviews: list_interviews"
             + "\n7. Edit applicants/interviewers: edit [applicant/interviewer index] n/[newName]..."
-            + "\n8. Find person(s) by email/name/phone: find_[email/name/phone] [keyword1] [keyword2]..."
-            + "\n9. Filter interview(s) by date: filter_interviews_by_date [date in YYYY-MM-DD]";
+            + "\n8. Add and edit statuses for applicants/interviews: [applicant/interviewer]_status [phone] [status]"
+            + "\n9. Find person(s) by email/name/phone: find_[email/name/phone] [keyword1] [keyword2]..."
+            + "\n10. Filter interview(s) by date: filter_interviews_by_date [date in YYYY-MM-DD]"
+            + "\n11. Filter persons(s) by status: filter_by_status [status]";
     public static final String HELP_MESSAGE = "Refer to our user guide at " + USERGUIDE_URL + " for detailed info "
             + "on how to use Tether." + COMMON_COMMANDS;
 


### PR DESCRIPTION
Bug fixes
- Description: Similar to #121, when editing a `Person`, their `status` is overwritten to the default which is "resume review" for `Applicants` and "free" for `Interviewers.
- Fix: call `getCurrentStatus` on `personToEdit` instead 

Extension to current functionality
- Add ability to record multiple statuses for interviewers i.e. when interviews are added and removed, so are interviewer statuses
- Interviewers' `status' is now a `List` of `InterviewerStatus` and when `getCurrentStatus` is called for interviewers, the status list is stringified
- This extension was necessary also because the previous logic involved resetting the interviewer's status to "free" as long as any one of their interviews was deleted even if they still had some interviews scheduled still.

UI Changes
- Added information about status commands to help window
- Minor edits to `CommandResult`s for status commands 

Note
- Consult with team @macareonie @gingerbreaf @zhikaiong2001 @headcube1 whether best to remove ability for users to add interviewer statuses manually so as to not jeopardise manipulating of status list for interviewers