### PR TITLE
Implement and test computation and display of overall statistics

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInterviewCommand.java
@@ -18,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.interview.Interview;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.enums.Type;
 
 /**
  * Adds an Interview to Tether.
@@ -88,7 +89,7 @@ public class AddInterviewCommand extends Command {
                 isFoundApplicant = true;
             }
             if (isFoundApplicant) {
-                if (p.getPersonType().equals("APPLICANT")) {
+                if (p.getPersonType().equals(Type.APPLICANT.toString())) {
                     isIncorrectApplicantPhone = false;
                 }
                 applicantSearch = p;
@@ -100,7 +101,7 @@ public class AddInterviewCommand extends Command {
                 isFoundInterviewer = true;
             }
             if (isFoundInterviewer) {
-                if (p.getPersonType().equals("INTERVIEWER")) {
+                if (p.getPersonType().equals(Type.INTERVIEWER.toString())) {
                     isIncorrectInterviewerPhone = false;
                 }
                 interviewerSearch = p;

--- a/src/main/java/seedu/address/logic/commands/ViewOverallStatisticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewOverallStatisticsCommand.java
@@ -1,0 +1,103 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.enums.ApplicantState;
+import seedu.address.model.person.enums.InterviewerState;
+import seedu.address.model.person.enums.Type;
+
+/**
+ * Displays preselected person and interview statistics for the currently filtered person and interview lists.
+ */
+public class ViewOverallStatisticsCommand extends Command {
+
+    public static final String COMMAND_WORD = "view_overall_statistics";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays overall statistics for the currently "
+            + "displayed list.";
+
+    /**
+     * Creates a ViewOverallStatisticsCommand
+     */
+    public ViewOverallStatisticsCommand() {
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        String statisticsOverview = retrieveStatistics(model);
+        return new CommandResult(statisticsOverview);
+    }
+
+    private String retrieveStatistics(Model model) {
+        // String counts of applicants, interviewers, pending interviews
+        String numberOfApplicants = getFilteredPersonListCount(model, person ->
+                person.getPersonType().equals(Type.APPLICANT.toString()));
+        String numberOfInterviewers = getFilteredPersonListCount(model, person ->
+                person.getPersonType().equals(Type.INTERVIEWER.toString()));
+        String numberOfInterviews = "" + model.getAddressBook().getInterviewList().size();
+
+        // String count of interviewers by status
+        String numberOfFreeInterviewers = getFilteredPersonListCount(model, person ->
+                person.getCurrentStatus().equals(InterviewerState.FREE.toString()));
+        String numberOfOccupiedInterviewers = "" + (Integer.parseInt(numberOfInterviewers)
+                - Integer.parseInt(numberOfFreeInterviewers));
+
+        // String of applicants by status
+        String numberOfApplicantsByStatus = retrieveApplicantStatusStatistics(model);
+
+        return "Number of applicants: "
+                + numberOfApplicants + " (" + numberOfApplicantsByStatus + ")"
+                + "\nNumber of interviewers: "
+                + numberOfInterviewers + " (Free: " + numberOfFreeInterviewers + ", Busy: "
+                + numberOfOccupiedInterviewers + ")\nNumber of interviews: "
+                + numberOfInterviews;
+    }
+
+    private String getFilteredPersonListCount(Model model, Predicate<Person> predicate) {
+        return "" + model.getAddressBook().getPersonList().stream().parallel().filter(predicate).count();
+    }
+
+    private String retrieveApplicantStatusStatistics(Model model) {
+        String numberOfReviewableApplicants = getFilteredPersonListCount(model, person ->
+                person.getCurrentStatus().equals(ApplicantState.STAGE_ONE.toString()));
+        String numberOfApplicantsPendingIntv = getFilteredPersonListCount(model, person ->
+                person.getCurrentStatus().equals(ApplicantState.STAGE_TWO.toString()));
+        String numberOfApplicantsCompletedIntv = getFilteredPersonListCount(model, person ->
+                person.getCurrentStatus().equals(ApplicantState.STAGE_THREE.toString()));
+        String numberOfApplicantsWaitlisted = getFilteredPersonListCount(model, person ->
+                person.getCurrentStatus().equals(ApplicantState.OUTCOME_ONE.toString()));
+        String numberOfApplicantsAccepted = getFilteredPersonListCount(model, person ->
+                person.getCurrentStatus().equals(ApplicantState.OUTCOME_TWO.toString()));
+        String numberOfApplicantsRejected = getFilteredPersonListCount(model, person ->
+                person.getCurrentStatus().equals(ApplicantState.OUTCOME_THREE.toString()));
+
+        return "Resume review: " + numberOfReviewableApplicants
+                + ", Pending interview: " + numberOfApplicantsPendingIntv
+                + ", Completed interview: " + numberOfApplicantsCompletedIntv
+                + ", Waiting list: " + numberOfApplicantsWaitlisted
+                + ", Accepted: " + numberOfApplicantsAccepted
+                + ", Rejected: " + numberOfApplicantsRejected;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        return other instanceof ViewOverallStatisticsCommand;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListInterviewsCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.ViewOverallStatisticsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -105,6 +106,9 @@ public class AddressBookParser {
 
         case FilterPersonsByStatusCommand.COMMAND_WORD:
             return new FilterPersonsByStatusCommandParser().parse(arguments);
+
+        case ViewOverallStatisticsCommand.COMMAND_WORD:
+            return new ViewOverallStatisticsCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -29,7 +29,8 @@ public class HelpWindow extends UiPart<Stage> {
             + "\n8. Add and edit statuses for applicants/interviews: [applicant/interviewer]_status [phone] [status]"
             + "\n9. Find person(s) by email/name/phone: find_[email/name/phone] [keyword1] [keyword2]..."
             + "\n10. Filter interview(s) by date: filter_interviews_by_date [date in YYYY-MM-DD]"
-            + "\n11. Filter persons(s) by status: filter_by_status [status]";
+            + "\n11. Filter persons(s) by status: filter_by_status [status]"
+            + "\n12. View overall statistics: view_overall_statistics";
     public static final String HELP_MESSAGE = "Refer to our user guide at " + USERGUIDE_URL + " for detailed info "
             + "on how to use Tether." + COMMON_COMMANDS;
 

--- a/src/test/java/seedu/address/logic/commands/ViewOverallStatisticsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewOverallStatisticsCommandTest.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class ViewOverallStatisticsCommandTest {
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_viewOverallStatisticsUnfilteredList_success() {
+        ViewOverallStatisticsCommand viewOverallStatisticsCommand = new ViewOverallStatisticsCommand();
+
+        String expectedMessage = "Number of applicants: 8"
+                + " (Resume review: 7, Pending interview: 1, Completed interview: 0, Waiting list: 0, Accepted: 0"
+                + ", Rejected: 0)" + "\nNumber of interviewers: "
+                + "1" + " (Free: 0, Busy: 1)" + "\nNumber of interviews: 0";
+
+        assertCommandSuccess(viewOverallStatisticsCommand, model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_viewOverallStatisticsFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        ViewOverallStatisticsCommand viewOverallStatisticsCommand = new ViewOverallStatisticsCommand();
+
+        String expectedMessage = "Number of applicants: 8"
+                + " (Resume review: 7, Pending interview: 1, Completed interview: 0, Waiting list: 0, Accepted: 0"
+                + ", Rejected: 0)" + "\nNumber of interviewers: "
+                + "1" + " (Free: 0, Busy: 1)" + "\nNumber of interviews: 0";
+
+        assertCommandSuccess(viewOverallStatisticsCommand, model, expectedMessage, model);
+    }
+
+    @Test
+    public void equals() {
+        final ViewOverallStatisticsCommand standardCommand = new ViewOverallStatisticsCommand();
+        final ViewOverallStatisticsCommand standardCommandCopy = new ViewOverallStatisticsCommand();
+
+        // same object -> return true
+        assertEquals(standardCommand, standardCommand);
+
+        // same type -> return true
+        assertEquals(standardCommand, standardCommandCopy);
+
+        // null -> return false
+        assertNotEquals(standardCommand, null);
+
+        // different types -> return false
+        assertNotEquals(standardCommand, new ClearCommand());
+
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,27 +15,35 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddApplicantPersonCommand;
+import seedu.address.logic.commands.AddApplicantStatusCommand;
 import seedu.address.logic.commands.AddInterviewerPersonCommand;
+import seedu.address.logic.commands.AddInterviewerStatusCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterPersonsByStatusCommand;
 import seedu.address.logic.commands.FindEmailCommand;
 import seedu.address.logic.commands.FindNameCommand;
 import seedu.address.logic.commands.FindPhoneCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.ViewOverallStatisticsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Applicant;
+import seedu.address.model.person.ApplicantStatus;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.Interviewer;
+import seedu.address.model.person.InterviewerStatus;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.enums.ApplicantState;
+import seedu.address.model.person.enums.InterviewerState;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -89,6 +97,24 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_addApplicantStatus() throws Exception {
+        String phone = "98362254";
+        String status = ApplicantState.STAGE_ONE.toString();
+        AddApplicantStatusCommand command = (AddApplicantStatusCommand) parser.parseCommand(
+                AddApplicantStatusCommand.COMMAND_WORD + " " + phone + " s/" + status);
+        assertEquals(command, new AddApplicantStatusCommand(new Phone(phone), new ApplicantStatus(status)));
+    }
+
+    @Test
+    public void parseCommand_addInterviewerStatus() throws Exception {
+        String phone = "98362254";
+        String status = InterviewerState.FREE.toString();
+        AddInterviewerStatusCommand command = (AddInterviewerStatusCommand) parser.parseCommand(
+                AddInterviewerStatusCommand.COMMAND_WORD + " " + phone + " s/" + status);
+        assertEquals(command, new AddInterviewerStatusCommand(new Phone(phone), new InterviewerStatus(status)));
+    }
+
+    @Test
     public void parseCommand_find_email() throws Exception {
         List<String> keywords = Arrays.asList("foo@email.com", "bar@email.com", "baz@email.com");
         FindEmailCommand command = (FindEmailCommand) parser.parseCommand(
@@ -113,6 +139,21 @@ public class AddressBookParserTest {
                 FindPhoneCommand.COMMAND_WORD + " "
                         + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindPhoneCommand(new PhoneContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_filterPersonsByStatus() throws Exception {
+        FilterPersonsByStatusCommand command = (FilterPersonsByStatusCommand) parser.parseCommand(
+                FilterPersonsByStatusCommand.COMMAND_WORD + " resume review");
+        assertEquals(command, new FilterPersonsByStatusCommand(
+                new ApplicantStatus(ApplicantState.STAGE_ONE.toString())));
+    }
+
+    @Test
+    public void parseCommand_viewOverallStatistics() throws Exception {
+        ViewOverallStatisticsCommand command = (ViewOverallStatisticsCommand) parser.parseCommand(
+                ViewOverallStatisticsCommand.COMMAND_WORD);
+        assertEquals(new ViewOverallStatisticsCommand(), command);
     }
 
     @Test


### PR DESCRIPTION
## New Feature for #127 

Users can now view the following overall statistics using `view_overall_statistics`: 
- Number of applicants including breakdown by status
- Number of interviewers including breakdown by status
- Number of interviews