### PR TITLE
Fix bug with duplicate persons check

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddApplicantPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApplicantPersonCommand.java
@@ -20,8 +20,8 @@ public class AddApplicantPersonCommand extends AddPersonCommand {
 
 
     public static final String MESSAGE_SUCCESS = "New applicant added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This applicant already exists in Tether."
-            + " Do ensure phone number is unique";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in Tether."
+            + " Do ensure phone number and email are unique!";
 
 
     /**
@@ -35,7 +35,7 @@ public class AddApplicantPersonCommand extends AddPersonCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd) || model.hasPersonWithSamePhone(toAdd)) {
+        if (model.hasPerson(toAdd) || model.hasPersonWithSamePhone(toAdd) || model.hasPersonWithSameEmail(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddInterviewerPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInterviewerPersonCommand.java
@@ -19,8 +19,8 @@ public class AddInterviewerPersonCommand extends AddPersonCommand {
             + AddPersonCommand.MESSAGE_USAGE;
 
     public static final String MESSAGE_SUCCESS = "New interviewer added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This interviewer already exists in the Tether."
-            + " Do ensure phone number is unique";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the Tether."
+            + " Do ensure phone number and email are unique!";
 
     /**
      * Creates an AddInterviewerCommand to add the specified {@code Person}
@@ -33,7 +33,7 @@ public class AddInterviewerPersonCommand extends AddPersonCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd) || model.hasPersonWithSamePhone(toAdd)) {
+        if (model.hasPerson(toAdd) || model.hasPersonWithSamePhone(toAdd) || model.hasPersonWithSameEmail(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -82,6 +82,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a person with the same email as {@code person} exists in the address book.
+     */
+    public boolean hasPersonWithSameEmail(Person person) {
+        requireNonNull(person);
+        return persons.containsSameEmail(person);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -65,6 +65,11 @@ public interface Model {
     boolean hasPersonWithSamePhone(Person person);
 
     /**
+     * Returns true if a person with the same email as {@code person} exists in the address book.
+     */
+    boolean hasPersonWithSameEmail(Person person);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -104,6 +104,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPersonWithSameEmail(Person person) {
+        requireNonNull(person);
+        return addressBook.hasPersonWithSameEmail(person);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -45,6 +45,14 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns true if the list contains a person with an equivalent email as the given argument.
+     */
+    public boolean containsSameEmail(Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(person -> person.getEmail().equals(toCheck.getEmail()));
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
@@ -156,6 +156,11 @@ public class AddApplicantCommandTest {
         }
 
         @Override
+        public boolean hasPersonWithSameEmail(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasInterview(Interview interview) {
             throw new AssertionError("This method should not be called.");
         }
@@ -230,6 +235,12 @@ public class AddApplicantCommandTest {
         public boolean hasPersonWithSamePhone(Person person) {
             requireNonNull(person);
             return personsAdded.stream().anyMatch(p -> p.getPhone().equals(person.getPhone()));
+        }
+
+        @Override
+        public boolean hasPersonWithSameEmail(Person person) {
+            requireNonNull(person);
+            return personsAdded.stream().anyMatch(p -> p.getEmail().equals(person.getEmail()));
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddInterviewerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddInterviewerCommandTest.java
@@ -155,6 +155,11 @@ public class AddInterviewerCommandTest {
         }
 
         @Override
+        public boolean hasPersonWithSameEmail(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasInterview(Interview interview) {
             throw new AssertionError("This method should not be called.");
         }
@@ -236,6 +241,12 @@ public class AddInterviewerCommandTest {
         public boolean hasPersonWithSamePhone(Person person) {
             requireNonNull(person);
             return personsAdded.stream().anyMatch(p -> p.getPhone().equals(person.getPhone()));
+        }
+
+        @Override
+        public boolean hasPersonWithSameEmail(Person person) {
+            requireNonNull(person);
+            return personsAdded.stream().anyMatch(p -> p.getEmail().equals(person.getEmail()));
         }
 
         @Override


### PR DESCRIPTION
AddApplicant and AddInterviewer now properly checks that for persons with duplicate phone number OR email and ensures that an error message will be thrown stating that the person already exists in Tether.

Relevant Junit tests and Stubs have been updated accordingly.

Related to #223 