### PR TITLE
Remove unnecessary code parts

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -111,7 +111,9 @@ To record an applicant and their contact details in Tether, simply execute `add_
     - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.
 
 **Notes**:
-* Different applicants with the same name can be added as long as their phone numbers and emails are different.
+* No two applicants can have the same email or phone number.
+  * For two applicants to be considered different, they must have different emails AND different phone numbers.
+  * For the discrete mathematics enthusiasts, this is equivalent to `~(sameEmail || samePhone) = ~sameEmail && ~ samePhone = differentEmail && differentPhone`.
 * Applicants' remark field will be empty by default and can only be edited later with the `remark` command (described below).
 
 ### Adding a status to an applicant:
@@ -153,7 +155,7 @@ To record an applicant and their contact details in Tether, simply execute `add_
 ![img_2.png](img_2.png)
 
 **Notes**:
-* Similar to applicants, different interviewers with the same names can be added as long as their phone numbers and emails are different.
+* Similar to applicants, no two interviewers can have the same email or phone number. 
 * Interviewers' remark field will be empty by default and can only be edited later with the `remark` command (described below).
 
 ### Adding a status to an interviewer:

--- a/src/main/java/seedu/address/logic/commands/AddApplicantPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApplicantPersonCommand.java
@@ -29,8 +29,7 @@ public class AddApplicantPersonCommand extends AddPersonCommand {
 
 
     public static final String MESSAGE_SUCCESS = "New applicant added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in Tether."
-            + " Do ensure phone number and email are unique!";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in Tether.";
 
 
     /**
@@ -44,7 +43,7 @@ public class AddApplicantPersonCommand extends AddPersonCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd) || model.hasPersonWithSamePhone(toAdd) || model.hasPersonWithSameEmail(toAdd)) {
+        if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddInterviewerPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInterviewerPersonCommand.java
@@ -28,8 +28,7 @@ public class AddInterviewerPersonCommand extends AddPersonCommand {
             + PREFIX_TAG + "friends ";
 
     public static final String MESSAGE_SUCCESS = "New interviewer added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the Tether."
-            + " Do ensure phone number and email are unique!";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in Tether.";
 
     /**
      * Creates an AddInterviewerCommand to add the specified {@code Person}
@@ -42,7 +41,7 @@ public class AddInterviewerPersonCommand extends AddPersonCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd) || model.hasPersonWithSamePhone(toAdd) || model.hasPersonWithSameEmail(toAdd)) {
+        if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -74,22 +74,6 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Returns true if a person with the same phone as {@code person} exists in the address book.
-     */
-    public boolean hasPersonWithSamePhone(Person person) {
-        requireNonNull(person);
-        return persons.containsSamePhone(person);
-    }
-
-    /**
-     * Returns true if a person with the same email as {@code person} exists in the address book.
-     */
-    public boolean hasPersonWithSameEmail(Person person) {
-        requireNonNull(person);
-        return persons.containsSameEmail(person);
-    }
-
-    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -60,16 +60,6 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
-     * Returns true if a person with the same phone as {@code person} exists in the address book.
-     */
-    boolean hasPersonWithSamePhone(Person person);
-
-    /**
-     * Returns true if a person with the same email as {@code person} exists in the address book.
-     */
-    boolean hasPersonWithSameEmail(Person person);
-
-    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -98,18 +98,6 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasPersonWithSamePhone(Person person) {
-        requireNonNull(person);
-        return addressBook.hasPersonWithSamePhone(person);
-    }
-
-    @Override
-    public boolean hasPersonWithSameEmail(Person person) {
-        requireNonNull(person);
-        return addressBook.hasPersonWithSameEmail(person);
-    }
-
-    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -86,7 +86,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons of the same name have at least one other identity field that is the same.
+     * Returns true if both persons of the have either email or phone number field that is the same.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -95,7 +95,6 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName())
                 && (otherPerson.getPhone().equals(getPhone()) || otherPerson.getEmail().equals(getEmail()));
     }
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -36,21 +36,6 @@ public class UniquePersonList implements Iterable<Person> {
         return internalList.stream().anyMatch(toCheck::isSamePerson);
     }
 
-    /**
-     * Returns true if the list contains a person with an equivalent phone number as the given argument.
-     */
-    public boolean containsSamePhone(Person toCheck) {
-        requireNonNull(toCheck);
-        return internalList.stream().anyMatch(person -> person.getPhone().equals(toCheck.getPhone()));
-    }
-
-    /**
-     * Returns true if the list contains a person with an equivalent email as the given argument.
-     */
-    public boolean containsSameEmail(Person toCheck) {
-        requireNonNull(toCheck);
-        return internalList.stream().anyMatch(person -> person.getEmail().equals(toCheck.getEmail()));
-    }
 
     /**
      * Adds a person to the list.

--- a/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
@@ -151,16 +151,6 @@ public class AddApplicantCommandTest {
         }
 
         @Override
-        public boolean hasPersonWithSamePhone(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPersonWithSameEmail(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public boolean hasInterview(Interview interview) {
             throw new AssertionError("This method should not be called.");
         }
@@ -229,18 +219,6 @@ public class AddApplicantCommandTest {
         public boolean hasPerson(Person person) {
             requireNonNull(person);
             return personsAdded.stream().anyMatch(person::isSamePerson);
-        }
-
-        @Override
-        public boolean hasPersonWithSamePhone(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(p -> p.getPhone().equals(person.getPhone()));
-        }
-
-        @Override
-        public boolean hasPersonWithSameEmail(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(p -> p.getEmail().equals(person.getEmail()));
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddInterviewerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddInterviewerCommandTest.java
@@ -150,16 +150,6 @@ public class AddInterviewerCommandTest {
         }
 
         @Override
-        public boolean hasPersonWithSamePhone(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPersonWithSameEmail(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public boolean hasInterview(Interview interview) {
             throw new AssertionError("This method should not be called.");
         }
@@ -235,18 +225,6 @@ public class AddInterviewerCommandTest {
         public void addPerson(Person person) {
             requireNonNull(person);
             personsAdded.add(person);
-        }
-
-        @Override
-        public boolean hasPersonWithSamePhone(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(p -> p.getPhone().equals(person.getPhone()));
-        }
-
-        @Override
-        public boolean hasPersonWithSameEmail(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(p -> p.getEmail().equals(person.getEmail()));
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -252,16 +252,6 @@ public class DeleteCommandTest {
         }
 
         @Override
-        public boolean hasPersonWithSamePhone(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPersonWithSameEmail(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public boolean hasInterview(Interview interview) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -83,17 +83,17 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasPersonWithSamePhone_personWithSamePhoneInAddressBook_returnsTrue() {
+    public void hasPerson_personWithSamePhoneInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
         Person editedAlice = new PersonBuilder(ALICE).withEmail("alice@example.org").build();
-        assertTrue(addressBook.hasPersonWithSamePhone(editedAlice));
+        assertTrue(addressBook.hasPerson(editedAlice));
     }
 
     @Test
-    public void hasPersonWithSamePhone_personWithDifferentPhoneInAddressBook_returnsFalse() {
+    public void hasPerson_personWithDifferentPhoneInAddressBook_returnsFalse() {
         addressBook.addPerson(ALICE);
         Person bob = new PersonBuilder().withPhone("11111111").build(); // Use a phone number not used by ALICE
-        assertFalse(addressBook.hasPersonWithSamePhone(bob));
+        assertFalse(addressBook.hasPerson(bob));
     }
 
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -34,9 +34,9 @@ public class PersonTest {
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // different name -> returns false
+        // different name, same phone, same email -> returns true
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        assertTrue(ALICE.isSamePerson(editedAlice));
 
         // same name, same phone, different attributes -> returns true
         editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB)


### PR DESCRIPTION
Recent changes to add applicant and interviewer functionalities have been reverted to comply with v1.4 feature freeze.

Upon greater inspection of code, certain checks for duplicate fields in the above code have been removed as it caused confusion. Intended functionailty was already implemented in earlier versions.

User Guide documentation for add applicants and interviewers have been slightly modifed for greater clarity.